### PR TITLE
Add docs/README.md: OctoAcme project management overview — links to #2

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,21 @@
+# OctoAcme Project Management Docs — README
+
+OctoAcme runs projects with an emphasis on iterative delivery, clear ownership, and measurable outcomes. Projects begin with a lightweight Project One-pager to confirm the problem, success metrics, stakeholders, and a high-level timeline. Planning breaks work into shippable increments, captures dependencies and risks, and establishes a Definition of Done and release plan.
+
+Day-to-day execution uses a simple project board workflow (Backlog → Ready → In Progress → In Review → QA → Done) and a disciplined pull request process: small PRs linked to issues with acceptance criteria, automated CI checks, and required reviews before merging. Team rhythm includes daily standups, a weekly delivery sync, and demos at the end of sprints or milestones. Planning emphasizes prioritized backlogs, estimates, and clear acceptance criteria.
+
+Roles and responsibilities are spelled out so accountabilities are clear: Product Managers (PdM) own outcomes and metrics, Project Managers (PM) coordinate schedules and communication, Developers implement features and tests, and QA validates acceptance criteria. Core artifacts include the Project One-pager, backlog, release plan, acceptance criteria, and a Risk Register.
+
+Quality assurance and release discipline are enforced via CI (unit, integration, and security scans), smoke tests for critical flows, and manual QA where needed. Releases follow type-specific checklists, require passing CI and pre-release checks, a rollback plan, and post-deploy verification. For details, see the linked process documents below.
+
+Process documentation index
+- [Project Management Overview](octoacme-project-management-overview.md)
+- [Project Initiation Guide](octoacme-project-initiation.md)
+- [Project Planning](octoacme-project-planning.md)
+- [Execution & Tracking](octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md)
+- [Roles and Personas](octoacme-roles-and-personas.md)
+
+If you want to propose an update to any doc, please use the repository's process doc issue template: .github/ISSUE_TEMPLATE/add-update-content-to-process-docs.yml


### PR DESCRIPTION
This adds docs/README.md: a brief summary of OctoAcme project management processes and direct links to the process docs in /docs.\n\nRefs #2